### PR TITLE
A few fixes and refinements to the test setup

### DIFF
--- a/hippiehug-package/hippiehug/Nodes.py
+++ b/hippiehug-package/hippiehug/Nodes.py
@@ -10,10 +10,12 @@ class Leaf:
     __slots__ = ["key", "item", "hid"]
 
     def __init__(self, item, key):
+        assert isinstance(item, bytes)
         self.item = item
         """ The item stored in the Leaf. """
 
         assert key is not None
+        assert isinstance(key, bytes)
         self.key = key
         """ The key under which the item is stored in the leaf. """
 
@@ -119,7 +121,7 @@ class Branch:
 
             new_b_left = b_left.add(store, item, key)
             b = Branch(self.pivot, new_b_left.hid, self.right_branch)
-            
+
         else:
             b_right = store[self.right_branch]
             _check_hash(self.right_branch, b_right)
@@ -173,7 +175,7 @@ class Branch:
     def lookup(self, store, key):
         if key <= self.pivot:
             return store[self.left_branch].lookup(store, key)
-        else:   
+        else:
             return store[self.right_branch].lookup(store, key)
 
 
@@ -182,7 +184,7 @@ class Branch:
 
         if key <= self.pivot:
             return store[self.left_branch].is_in(store, item, key)
-        else:   
+        else:
             return store[self.right_branch].is_in(store, item, key)
 
 
@@ -191,14 +193,14 @@ class Branch:
             return
 
         assert keys is not None
-        
+
         assert len(items) == len(keys)
         work_list = [(self, items, keys)]
 
         while work_list != []:
 
             (work_node, work_items, work_keys) = work_list.pop()
-            
+
             if evidence is not None:
                 evidence.append( work_node )
 
@@ -230,7 +232,7 @@ class Branch:
                 if left_list != []:
                     _check_hash(work_node.left_branch, b_left)
                     work_list.append( (b_left, left_list, left_keys) )
-                    
+
                 b_right = store[work_node.right_branch]
                 if right_list != []:
                     _check_hash(work_node.right_branch, b_right)
@@ -241,7 +243,7 @@ class Branch:
         evidence = evidence + [ self ]
         if key <= self.pivot:
             return store[self.left_branch].evidence(store, evidence, key)
-        else:   
+        else:
             return store[self.right_branch].evidence(store, evidence, key)
 
     def check(self, store):

--- a/hippiehug-package/hippiehug/RedisChain.py
+++ b/hippiehug-package/hippiehug/RedisChain.py
@@ -89,12 +89,12 @@ class RedisChain():
 
 import pytest
 
-@pytest.mark.skip(reason="no redis")
 def test_init():
+    pytest.importorskip("redis")
     rc = RedisChain(b"test1")
 
-@pytest.mark.skip(reason="no redis")
 def test_get_set():
+    pytest.importorskip("redis")
     rc = RedisChain(b"test1")
 
     d = Document(b"Hello")
@@ -111,9 +111,8 @@ def test_get_set():
     b2 = rc[b.hid]
     assert b == b2
 
-@pytest.mark.skip(reason="no redis")
 def test_create_add():
-
+    pytest.importorskip("redis")
     rc = RedisChain(b"test3")
     rc.add([b"Hello1",b"World2"])
 

--- a/hippiehug-package/hippiehug/RedisStore.py
+++ b/hippiehug-package/hippiehug/RedisStore.py
@@ -22,7 +22,7 @@ def ext_hook(code, data):
     """ Deserialize objects using msgpack. """
     if code == 42:
         l_item, l_key = msgpack.unpackb(data)
-        return Leaf(l_item, l_key) 
+        return Leaf(l_item, l_key)
     if code == 43:
         piv, r_leaf, l_leaf = msgpack.unpackb(data)
         return Branch(piv, r_leaf, l_leaf)
@@ -31,17 +31,17 @@ def ext_hook(code, data):
 
 
 class RedisStore():
-    def __init__(self, host="localhost", port=6379, db=0):
+    def __init__(self, redisdb):
         """ Initialize a Redis backed store for the Merkle Tree. """
-        self.r = redis.StrictRedis(host=host, port=port, db=db)
+        self.r = redisdb
         self.cache = {}
 
     def __getitem__(self, key):
         if key in self.cache:
             return self.cache[key]
-        
+
         if len(self.cache) > 10000:
-            self.cache = {} 
+            self.cache = {}
 
         bdata = self.r.get(key)
         branch = msgpack.unpackb(bdata, ext_hook=ext_hook)

--- a/hippiehug-package/speedtest_chain.py
+++ b/hippiehug-package/speedtest_chain.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import cProfile
 from hippiehug import DocChain
 import StringIO
@@ -30,4 +32,4 @@ if __name__ == "__main__":
 	ps.sort_stats(sortby)
 	ps.strip_dirs()
 	ps.print_stats()
-	print s.getvalue()
+	print(s.getvalue())

--- a/hippiehug-package/speedtest_plain.py
+++ b/hippiehug-package/speedtest_plain.py
@@ -1,10 +1,11 @@
+from __future__ import print_function
 import cProfile
 from hippiehug import Tree
 import StringIO
 import pstats
 
 def main():
-	t = Tree()	
+	t = Tree()
 
 	from os import urandom
 	for _ in range(1000):
@@ -25,4 +26,4 @@ if __name__ == "__main__":
 	ps.sort_stats(sortby)
 	ps.strip_dirs()
 	ps.print_stats()
-	print s.getvalue()
+	print(s.getvalue())

--- a/hippiehug-package/speedtest_redis.py
+++ b/hippiehug-package/speedtest_redis.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import cProfile
 from hippiehug import Tree, RedisStore
 import StringIO
@@ -12,7 +13,7 @@ def _flushDB():
 
 def main():
 	r = RedisStore()
-	t = Tree(store=r)	
+	t = Tree(store=r)
 
 	from os import urandom
 	for _ in range(1000):
@@ -35,4 +36,4 @@ if __name__ == "__main__":
 	ps.strip_dirs()
 	ps.sort_stats(sortby)
 	ps.print_stats()
-	print s.getvalue()
+	print(s.getvalue())

--- a/hippiehug-package/tests/conftest.py
+++ b/hippiehug-package/tests/conftest.py
@@ -1,0 +1,13 @@
+import pytest
+from hippiehug.RedisStore import RedisStore
+
+@pytest.fixture
+def rstore():
+    redis = pytest.importorskip("redis")
+
+    # XXX we need to create our own Redis process/instance
+    # XXX instead of using and flushing (!) the global one
+    r = redis.StrictRedis()
+    r.flushdb()
+    return RedisStore(r)
+

--- a/hippiehug-package/tests/test_doc.py
+++ b/hippiehug-package/tests/test_doc.py
@@ -19,15 +19,14 @@ def test_evidence():
     t2 = Tree(store, root)
     assert b"World" in t2
 
-@pytest.mark.skip(reason="no redis")
 def test_store():
-    import redis
+    redis = pytest.importorskip("redis")
     r = redis.StrictRedis(host='localhost', port=6379, db=0)
     r.flushdb()
 
     from hippiehug import Tree, RedisStore
     r = RedisStore(host="localhost", port=6379, db=0)
-    t = Tree(store = r) 
+    t = Tree(store = r)
 
     t.add(b"Hello")
     assert b"Hello" in t

--- a/hippiehug-package/tests/test_doc.py
+++ b/hippiehug-package/tests/test_doc.py
@@ -19,15 +19,9 @@ def test_evidence():
     t2 = Tree(store, root)
     assert b"World" in t2
 
-def test_store():
-    redis = pytest.importorskip("redis")
-    r = redis.StrictRedis(host='localhost', port=6379, db=0)
-    r.flushdb()
-
-    from hippiehug import Tree, RedisStore
-    r = RedisStore(host="localhost", port=6379, db=0)
-    t = Tree(store = r)
-
+def test_store(rstore):
+    from hippiehug import Tree
+    t = Tree(store=rstore)
     t.add(b"Hello")
     assert b"Hello" in t
 

--- a/hippiehug-package/tests/test_tree.py
+++ b/hippiehug-package/tests/test_tree.py
@@ -1,15 +1,6 @@
-from hippiehug import Tree, Leaf, Branch
+from hippiehug import RedisStore, Tree, Leaf, Branch
 import pytest
 
-## ============= FIXTURES =================
-
-@pytest.fixture
-def rstore():
-    """ Provide a flushed StrictRedis localhost instance. """
-    redis = pytest.importorskip("redis")
-    r = redis.StrictRedis(host='localhost', port=6379, db=0)
-    r.flushdb()
-    return r
 
 ## ============== TESTS ===================
 
@@ -30,7 +21,6 @@ def test_evidence():
 
 
 def test_store(rstore):
-    r = rstore
     l = Leaf(b"Hello", b"Hello")
     rstore[l.identity()] = l
     assert rstore[l.identity()].identity() == l.identity()
@@ -238,17 +228,17 @@ def test_double_add():
 
 def test_tree_default_store():
     t = Tree()
-    t.multi_add(["test"])
-    assert t.is_in("test")
+    t.multi_add([b"test"])
+    assert t.is_in(b"test")
 
     t2 = Tree()
-    assert not t2.is_in("test")
+    assert not t2.is_in(b"test")
 
 def test_tree_empty_store():
     store = {}
     t = Tree(store)
-    t.multi_add(["test"])
-    assert t.is_in("test")
+    t.multi_add([b"test"])
+    assert t.is_in(b"test")
 
     t2 = Tree(store, root_hash=t.root())
-    assert t2.is_in("test")
+    assert t2.is_in(b"test")

--- a/hippiehug-package/tox.ini
+++ b/hippiehug-package/tox.ini
@@ -8,7 +8,8 @@ envlist = py27, py35
 
 [testenv]
 commands =
-	pytest -sv --doctest-modules hippiehug {posargs}
+	pytest --disable-warnings -sv --doctest-modules hippiehug 
+    pytest --disable-warnings -sv {posargs:tests}
 
 deps =
   pytest

--- a/hippiehug-package/tox.ini
+++ b/hippiehug-package/tox.ini
@@ -8,7 +8,7 @@ envlist = py27, py35
 
 [testenv]
 commands =
-	pytest -sv --doctest-modules hippiehug
+	pytest -sv --doctest-modules hippiehug {posargs}
 
 deps =
   pytest


### PR DESCRIPTION
While looking through the code i fixed and refined a couple of test related things:

- use ``pytest.importorskip('redis')`` in some places which skips a running test
  if redis can not be imported

- use a "rstore" fixture which gives a readymade RedisStore instance for use in tests

- have tox run on py27 and py35 pass with all tests 

there also are a few whitespace-changes which relates to common practises i have configured in my editor.  Let me know if that bothers you. 
  