### PR TITLE
fix Block constructor to be more resilient

### DIFF
--- a/hippiehug-package/.gitignore
+++ b/hippiehug-package/.gitignore
@@ -36,6 +36,7 @@ pip-delete-this-directory.txt
 
 # Unit test / coverage reports
 htmlcov/
+.pytest_cache/
 .tox/
 .coverage
 .coverage.*

--- a/hippiehug-package/hippiehug/Chain.py
+++ b/hippiehug-package/hippiehug/Chain.py
@@ -1,4 +1,4 @@
-from copy import copy
+from copy import copy, deepcopy
 from binascii import hexlify
 from msgpack import packb
 
@@ -34,10 +34,10 @@ class Document:
 class Block:
     def __init__(self, items, index=0, fingers=None, aux=None):
         """Initialize a block."""
-        self.items = items
+        self.items = deepcopy(items)
         self.index = index
-        self.fingers = fingers or []
-        self.aux = None
+        self.fingers = deepcopy(fingers) if fingers else []
+        self.aux = deepcopy(aux)
 
     def hash(self):
         """Return the head of the block."""

--- a/hippiehug-package/setup.py
+++ b/hippiehug-package/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='hippiehug',
-      version='0.1.1',
+      version='0.1.2',
       description='A Merkle Tree implementation with a flexible storage backend.',
       author='George Danezis',
       author_email='g.danezis@ucl.ac.uk',

--- a/hippiehug-package/tests/test_chain.py
+++ b/hippiehug-package/tests/test_chain.py
@@ -8,6 +8,28 @@ def test_block_hash():
 
     b1 = b0.next_block(store, [b"item3", b"item4"])
 
+def test_block_duplicated():
+    b0 = Block(items=[b"item1", b"item2"], index=0, fingers=[b"A", b"B"], aux=42)
+    assert b0.aux == 42
+
+    b1 = Block(b0.items, b0.index, b0.fingers, b0.aux)
+
+    assert b0.items == b1.items
+    assert b0.index == b1.index
+    assert b0.fingers == b1.fingers
+    assert b0.aux == b1.aux
+
+def test_block_constructor_independence():
+    items, fingers, aux = [], [], []
+    b0 = Block(items, 0, fingers, aux)
+    items.append(1)
+    fingers.append(1)
+    aux.append(1)
+    assert b0.items == []
+    assert b0.fingers == []
+    assert b0.aux == []
+
+
 def test_block_find():
     store = {}
     b0 = Block( [b"item1", b"item2"], 0, [])


### PR DESCRIPTION
@azul and me worked on some claimchain / muacrypt / autocrypt integration and here is a simple PR that fixes the constructor of the Block class (wrt to initializating aux) and with respect to a caller modifying the mutable objects which one passes in. 