### PR TITLE
sort dicts before calculating hashes

### DIFF
--- a/hippiehug-package/hippiehug/Chain.py
+++ b/hippiehug-package/hippiehug/Chain.py
@@ -14,6 +14,17 @@ def check_hash(key, val):
         raise Exception("Value has the wrong hash.")
 
 
+def sort_dicts(unsorted):
+    if isinstance(unsorted, dict):
+        return sorted({k: sort_dicts(v) for k,v in unsorted.items()})
+    if isinstance(unsorted, list):
+        # do not sort lists. they do have a defined order already.
+        # we need to sort their elements though.
+        return [sort_dicts(e) for e in unsorted]
+    else:
+        return unsorted
+
+
 class Document:
     __slots__ = ["item", "hid"]
 
@@ -42,7 +53,7 @@ class Block:
     def hash(self):
         """Return the head of the block."""
         return binary_hash(packb(
-                ("S", self.index, self.fingers, self.items, self.aux)))
+                ("S", self.index, self.fingers, sort_dicts(self.items), self.aux)))
 
     @property
     def hid(self):

--- a/hippiehug-package/hippiehug/Chain.py
+++ b/hippiehug-package/hippiehug/Chain.py
@@ -16,7 +16,8 @@ def check_hash(key, val):
 
 def sort_dicts(unsorted):
     if isinstance(unsorted, dict):
-        return sorted({k: sort_dicts(v) for k,v in unsorted.items()})
+        values_sorted = {k: sort_dicts(v) for k,v in unsorted.items()}
+        return sorted(values_sorted.items())
     if isinstance(unsorted, list):
         # do not sort lists. they do have a defined order already.
         # we need to sort their elements though.

--- a/hippiehug-package/tests/test_chain.py
+++ b/hippiehug-package/tests/test_chain.py
@@ -8,6 +8,7 @@ def test_block_hash():
 
     b1 = b0.next_block(store, [b"item3", b"item4"])
 
+
 def test_block_duplicated():
     b0 = Block(items=[b"item1", b"item2"], index=0, fingers=[b"A", b"B"], aux=42)
     assert b0.aux == 42
@@ -18,6 +19,28 @@ def test_block_duplicated():
     assert b0.index == b1.index
     assert b0.fingers == b1.fingers
     assert b0.aux == b1.aux
+
+
+def test_block_with_hash_duplicated():
+    cc = {
+        'mtr_hash': None,
+        'metadata': {
+            'params': {
+                'dh_pk': 'VVREziRt5sorx9pqi5xpj16t1ibH1XPmNPqXBfCRNZD',
+                'sig_pk': 'VVRF1XiSmteSYFVkBdu9VY588CyPNKymZ6igm9xoEgN',
+                'vrf_pk': 'VVRF2rC2EFimdovJ5yhSx3BLpKsTy7iMTnvsK6NDskB',
+                'rescue_pk': 'VVREycH7jJqvhoEfP7ejAxfz1DAe5cKBUi1zet5cjnt'
+            },
+            'identity_info': "I'm VVREziRt5sorx9pqi5xpj16t1ibH1XPmNPqXBfCRNZD"
+        },
+        'version': 1,
+        'nonce': 'Q3JTBfZr3Q1PZ1JRfx3KNn',
+        'timestamp': 1525089767.931872
+    }
+    b0 = Block(items=[cc], index=0, fingers=[], aux=42)
+    b1 = Block(b0.items, b0.index, b0.fingers, b0.aux)
+    assert b0.hid == b1.hid
+
 
 def test_block_constructor_independence():
     items, fingers, aux = [], [], []
@@ -43,6 +66,7 @@ def test_block_find():
     res1 =  b0.get_item(store, 50, 30)
     assert res1 == b"50|30"
     assert b0.get_item(store, 0, 1) == b"item2"
+
 
 def test_chain():
     vals = []

--- a/hippiehug-package/tests/test_chain.py
+++ b/hippiehug-package/tests/test_chain.py
@@ -37,9 +37,12 @@ def test_block_with_hash_duplicated():
         'nonce': 'Q3JTBfZr3Q1PZ1JRfx3KNn',
         'timestamp': 1525089767.931872
     }
-    b0 = Block(items=[cc], index=0, fingers=[], aux=42)
-    b1 = Block(b0.items, b0.index, b0.fingers, b0.aux)
-    assert b0.hid == b1.hid
+    orig = Block(items=[cc], index=0, fingers=[], aux=42)
+    copy = Block(orig.items, orig.index, orig.fingers, orig.aux)
+    cc['timestamp'] = 1525089767.931234
+    changed_value = Block([cc], orig.index, orig.fingers, orig.aux)
+    assert orig.hid == copy.hid
+    assert orig.hid != changed_value.hid
 
 
 def test_block_constructor_independence():


### PR DESCRIPTION
Ran into this issue using Claimchain with a custom FileStore
backend.

We store the content of blocks in files and then load them.
Loading them requires instantiating the block from the values.
Since dict order is non-deterministic and the hid seems to
depend on it this leads to errors.

Includes a test.